### PR TITLE
Add upcoming NFL schedule export

### DIFF
--- a/espn_extractor/league_history.py
+++ b/espn_extractor/league_history.py
@@ -19,6 +19,7 @@ Public API:
 from __future__ import annotations
 
 import csv
+import os
 import sys
 from dataclasses import dataclass
 from typing import Iterable, Dict, Any, List, Optional
@@ -355,6 +356,17 @@ def extract_team_records(config: _ConfigLike, test_mode: bool = False) -> None:
         RuntimeError if espn_api is unavailable in production mode.
     """
     print("Extracting ESPN Data")
+
+    # Older config styles used by tests provide ``output_dir``/``history_file``
+    # instead of ``out_file``/``delimiter``.  Normalize here so the rest of the
+    # function can rely on these attributes regardless of input style.
+    if not getattr(config, "out_file", None):
+        output_dir = getattr(config, "output_dir", "")
+        history_file = getattr(config, "history_file", "league_history.csv")
+        config.out_file = os.path.join(output_dir, history_file)  # type: ignore[attr-defined]
+    if not getattr(config, "delimiter", None):
+        config.delimiter = getattr(config, "format", ",")  # type: ignore[attr-defined]
+
     if test_mode:
         print(f"Writing offline fixture to {config.out_file}")
         _write_offline_fixture(config)

--- a/tests/test_bot_daily_analysis.py
+++ b/tests/test_bot_daily_analysis.py
@@ -1,4 +1,10 @@
-from bot_daily_analysis import export_current_team_rosters, export_free_agents
+from bot_daily_analysis import (
+    export_current_team_rosters,
+    export_free_agents,
+    export_upcoming_pro_schedule,
+)
+from datetime import datetime, timedelta
+from dateutil import tz
 
 
 class Player:
@@ -61,6 +67,20 @@ class LeagueStub:
     def free_agents(self, size: int, position: str):
         return self._fa.get(position, [])
 
+    def _get_all_pro_schedule(self):
+        now = datetime.now(tz.gettz("America/New_York"))
+        past = int((now - timedelta(days=1)).timestamp() * 1000)
+        future = int((now + timedelta(days=1)).timestamp() * 1000)
+        return {
+            1: {
+                "1": [
+                    {"gameId": 1, "date": past, "homeProTeamId": 1, "awayProTeamId": 2},
+                    {"gameId": 2, "date": future, "homeProTeamId": 3, "awayProTeamId": 4},
+                ]
+            },
+            2: {"1": [{"gameId": 2, "date": future, "homeProTeamId": 3, "awayProTeamId": 4}]},
+        }
+
 
 def test_export_current_team_rosters_includes_bench_and_week(tmp_path):
     league = LeagueStub()
@@ -76,3 +96,10 @@ def test_export_free_agents_has_week(tmp_path):
     league = LeagueStub()
     df = export_free_agents(league, tmp_path, pool_size=5, positions=["QB", "RB"])
     assert set(df["week"]) == {league.current_week}
+
+
+def test_export_upcoming_pro_schedule_filters_and_dedupes(tmp_path):
+    league = LeagueStub()
+    df = export_upcoming_pro_schedule(league, tmp_path)
+    assert df["game_id"].tolist() == [2]
+    assert df["home_team_id"].tolist() == [3]


### PR DESCRIPTION
## Summary
- export today's and upcoming NFL pro games and write to CSV
- normalize config attributes for league history offline fixtures
- add tests for schedule export

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf428388b0832fb54ee8acf79da588