### PR TITLE
Add pro team abbreviations to pro schedule export

### DIFF
--- a/bot_daily_analysis.py
+++ b/bot_daily_analysis.py
@@ -12,7 +12,7 @@ try:
 except ModuleNotFoundError:
     import tomli as tomllib
 
-from espn_api.football import League
+from espn_api.football import League, constant
 
 
 # --------------------------
@@ -311,6 +311,8 @@ def export_upcoming_pro_schedule(league: League, out_dir: str) -> pd.DataFrame:
                             "game_date": game_dt.strftime("%Y-%m-%d"),
                             "home_team_id": g.get("homeProTeamId"),
                             "away_team_id": g.get("awayProTeamId"),
+                            "home_team_abbrev": constant.PRO_TEAM_MAP.get(g.get("homeProTeamId")),
+                            "away_team_abbrev": constant.PRO_TEAM_MAP.get(g.get("awayProTeamId")),
                         }
                     )
                     seen.add(game_id)

--- a/tests/test_bot_daily_analysis.py
+++ b/tests/test_bot_daily_analysis.py
@@ -103,3 +103,5 @@ def test_export_upcoming_pro_schedule_filters_and_dedupes(tmp_path):
     df = export_upcoming_pro_schedule(league, tmp_path)
     assert df["game_id"].tolist() == [2]
     assert df["home_team_id"].tolist() == [3]
+    assert df["home_team_abbrev"].tolist() == ["CHI"]
+    assert df["away_team_abbrev"].tolist() == ["CIN"]


### PR DESCRIPTION
## Summary
- include home and away team abbreviations in upcoming pro schedule export
- test that schedule export returns team abbreviations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf5c3ca54c832f88b87df3e288e875